### PR TITLE
Update README and manifests for log-output and ping-pong applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 - [1.13.](https://github.com/patrikwm/KubernetesSubmissions/tree/1.13/todo_app/)
 - [2.1.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.1/log_output/)
 - [2.2.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.2/todo-app/)
+- [2.2.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.2/todo-app/)
+- [2.3.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.3/log_output/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 - [1.13.](https://github.com/patrikwm/KubernetesSubmissions/tree/1.13/todo_app/)
 - [2.1.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.1/log_output/)
 - [2.2.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.2/todo-app/)
-- [2.2.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.2/todo-app/)
 - [2.3.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.3/log_output/)
 
 

--- a/log_output/README.md
+++ b/log_output/README.md
@@ -1,62 +1,94 @@
 
-# Chapter 2
+# Chapter 3
 
 
 ## Table of Contents
 
-## 2.1. Connecting pods
+## 2.3. Keep them separated
 
-
-### Shut down todo_app
+Create namespace
 
 ```bash
-➜ k delete -f todo_app/manifests
-deployment.apps "todo-app-deployment" deleted
-ingress.networking.k8s.io "todo-app-ingress" deleted
-service "todo-app-svc" deleted
+➜ k create namespace exercises
+namespace/exercises created
 ```
 
-### Deploy new ping-pong and todo_app
+- In previous exercise i deleted the log_output app because of path collission. Now i change path to /logs so they can run parallel.
+
+
+Deploy the applications to new namespace. Verify PVC is deployed to correct namespace.
 
 ```bash
-➜ k apply -f ping-pong_application/manifests -f log_output/manifests
-deployment.apps/ping-pong-deployment created
-ingress.networking.k8s.io/ping-pong-ingress created
-service/ping-pong-svc created
+➜ kubens default
+Context "k3d-k3s-default" modified.
+Active namespace is "default".
+➜ k get persistentvolumeclaims
+No resources found in default namespace.
+
+➜ kubens exercises
+Context "k3d-k3s-default" modified.
+Active namespace is "exercises".
+
+➜ k get persistentvolumeclaims
+NAME                    STATUS   VOLUME       CAPACITY   ACCESS MODES   STORAGECLASS        VOLUMEATTRIBUTESCLASS   AGE
+shared-volume-claim-0   Bound    agent-0-pv   1Gi        RWO            shared-agent-0-pv   <unset>                 58s
+```
+
+deploy apps to namespace
+
+```bash
+➜ k apply -f log_output/manifests -f ping-pong_application/manifests -n exercises --validate='strict'
 deployment.apps/log-output-deployment created
 ingress.networking.k8s.io/log-output-ingress created
 service/log-output-svc created
+deployment.apps/ping-pong-deployment created
+ingress.networking.k8s.io/ping-pong-ingress created
+service/ping-pong-svc created
+
+➜ k get deployments.apps
+NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
+log-output-deployment   1/1     1            1           7s
+ping-pong-deployment    1/1     1            1           7s
+
+➜ k get pods
+NAME                                     READY   STATUS    RESTARTS   AGE
+log-output-deployment-85bf5f5f5b-5zwmg   2/2     Running   0          10s
+ping-pong-deployment-78b976966c-n9jhs    1/1     Running   0          10s
 ```
 
-### Test ping-pong service and log-output service
-
-FIRT CALL 0 pings
+Test application
 
 ```bash
-➜ curl localhost:8081/
-HTTP Server ID: 2a536b97-3be0-42f6-8652-f5c9639ea28c
-Ping / Pongs: 0
-</br></br>Could not find logfile log_output.log%
-```
+➜ curl localhost:8081/logs
+HTTP Server ID: 68a01156-b53e-4539-8cf9-40a1f15269ef
+<br>Ping / Pongs: 0
+</br></br>2025-09-03 11:42:16,982 - INFO - Server started with hash Wa07GQUfGY
+<br>2025-09-03 11:42:16,982 - INFO - server id: Wa07GQUfGY - hash: Z1mBtREl2p
+<br>2025-09-03 11:43:07,229 - INFO - Server started with hash 7EHahLi0Ni
+<br>2025-09-03 11:43:07,229 - INFO - server id: 7EHahLi0Ni - hash: qbY9Pd2VPp
+<br>2025-09-03 11:43:12,230 - INFO - server id: 7EHahLi0Ni - hash: jGWvVq6kA6
+<br>2025-09-03 11:43:17,234 - INFO - server id: 7EHahLi0Ni - hash: QgSsDYDuIX
+<br>%
 
-Increase pingcounter by calling pingpong endpoint two times.
-
-```bash
-➜ curl localhost:8081/pingpong.
+➜ curl localhost:8081/pingpong
 {"counter":0,"message":"pong 0"}
+
 ➜ curl localhost:8081/pingpong
 {"counter":1,"message":"pong 1"}
-➜ curl localhost:8081/
-```
 
-Verify the counter increased two times and do not increase when calling log-output endpoint.
+➜ curl localhost:8081/logs
+HTTP Server ID: 68a01156-b53e-4539-8cf9-40a1f15269ef
+<br>Ping / Pongs: 2
+</br></br>2025-09-03 11:47:22,358 - INFO - server id: 7EHahLi0Ni - hash: ejzZAsh7z2
+<br>2025-09-03 11:47:27,362 - INFO - server id: 7EHahLi0Ni - hash: 2Kr3TCjCo6
+<br>2025-09-03 11:47:32,363 - INFO - server id: 7EHahLi0Ni - hash: kqCEjpiggX
+<br>2025-09-03 11:47:37,364 - INFO - server id: 7EHahLi0Ni - hash: h8cCWcIznQ
+<br>2025-09-03 11:47:42,366 - INFO - server id: 7EHahLi0Ni - hash: LlcmI1oT1z
+<br>2025-09-03 11:47:47,368 - INFO - server id: 7EHahLi0Ni - hash: 0hF7C3Usw6
+<br>2025-09-03 11:47:52,369 - INFO - server id: 7EHahLi0Ni - hash: fpOtdqKtpf
+<br>2025-09-03 11:47:57,370 - INFO - server id: 7EHahLi0Ni - hash: olTmjiqlvn
+<br>2025-09-03 11:48:02,373 - INFO - server id: 7EHahLi0Ni - hash: 8HukY1tq1b
+<br>2025-09-03 11:48:07,374 - INFO - server id: 7EHahLi0Ni - hash: 7MbVuMsQg5
+<br>%
 
-```bash
-HTTP Server ID: 2a536b97-3be0-42f6-8652-f5c9639ea28c
-Ping / Pongs: 2
-</br></br>Could not find logfile log_output log%
-➜ curl localhost:8081/
-HTTP Server ID: 2a536b97-3be0-42f6-8652-f5c9639ea28c
-Ping / Pongs: 2
-</br></br>Could not find logfile log_output.log%
 ```

--- a/log_output/log-reader.py
+++ b/log_output/log-reader.py
@@ -63,6 +63,7 @@ def fetch_ping_pong():
         return None
 
 @app.route('/')
+@app.route('/logs')
 def get_status():
     """Endpoint to get the current status (timestamp and random string)."""
     result = f"HTTP Server ID: {APP_HASH}\n<br>"

--- a/log_output/manifests/deployment.yaml
+++ b/log_output/manifests/deployment.yaml
@@ -12,20 +12,28 @@ spec:
       labels:
         app: logoutput
     spec:
+      volumes:
+        - name: shared-storage
+          persistentVolumeClaim:
+            claimName: shared-volume-claim-0
       containers:
         - name: log-reader
-          image: docker.io/pjmartin/log-reader:2.1@sha256:345499cd74f32cad14e5e2266f3bc5fa0aea0aefc2165a82c2a107158b0a9219
+          image: docker.io/pjmartin/log-reader:2.3@sha256:ce70245033939b68ff3a8cbde73c8daa42960033fa27ce874df21955c11e41af
           ports:
             - name: http
               containerPort: 3000
-          imagePullPolicy: Always
+          volumeMounts:
+            - name: shared-storage
+              mountPath: /app/data
           env:
             - name: DATA_ROOT
               value: "/app/data"
 
         - name: log-writer
-          image: docker.io/pjmartin/log-writer:1.12@sha256:69aa6a0250ff7200ed0cfcada2dddec238a0dab190ffe553941444cc46fa3891
-          imagePullPolicy: Always
+          image: docker.io/pjmartin/log-writer:2.3@sha256:6bb942841a896eb784f8e8c6c05b8d517ff272e2c03ae58ae372e08d0e01d1db
+          volumeMounts:
+            - name: shared-storage
+              mountPath: /app/data
           env:
             - name: DATA_ROOT
               value: "/app/data"

--- a/log_output/manifests/ingress.yaml
+++ b/log_output/manifests/ingress.yaml
@@ -6,7 +6,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /
+      - path: /logs
         pathType: Prefix
         backend:
           service:

--- a/log_output/manifests/service.yaml
+++ b/log_output/manifests/service.yaml
@@ -8,6 +8,6 @@ spec:
     app: logoutput
   ports:
     - name: http
-      port: 2345
       protocol: TCP
-      targetPort: http
+      port: 2345
+      targetPort: 3000

--- a/ping-pong_application/manifests/deployment.yaml
+++ b/ping-pong_application/manifests/deployment.yaml
@@ -14,10 +14,7 @@ spec:
     spec:
       containers:
         - name: pingpong
-          ports:
-            - name: http
-              containerPort: 3000
-          image: docker.io/pjmartin/pingpong:2.1@sha256:32acb1b02efd443b9ea4fae5ac1124ecac362c327b43af8b44788fee3f675ee0
+          image: docker.io/pjmartin/pingpong:2.3@sha256:628e68b2f07a8c1dd3a94ae462098d60221675bfca593dedcee958eba402c0ab
           env:
             - name: DATA_ROOT
               value: "/app/data"

--- a/ping-pong_application/manifests/service.yaml
+++ b/ping-pong_application/manifests/service.yaml
@@ -8,6 +8,6 @@ spec:
     app: pingpong
   ports:
     - name: http
-      port: 2345
       protocol: TCP
-      targetPort: http
+      port: 2345
+      targetPort: 3000


### PR DESCRIPTION
- Added links for exercises 2.3 in README.md
- Updated log-reader.py to include a new '/logs' endpoint
- Modified deployment.yaml to mount shared storage for log-reader and log-writer
- Adjusted ingress.yaml to route requests to the '/logs' path
- Updated service.yaml to ensure correct target ports for log-output and ping-pong services
- Updated ping-pong deployment and service manifests to use the latest image version