### PR TITLE
Add exercise 2.4 and update todo-app deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [2.1.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.1/log_output/)
 - [2.2.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.2/todo-app/)
 - [2.3.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.3/log_output/)
+- [2.4.](https://github.com/patrikwm/KubernetesSubmissions/tree/2.4/todo-app/)
 
 
 
@@ -28,7 +29,7 @@
 
 ### log_output
 
-endpoint: `/`
+endpoint: `/logs`
 
 Outputs a random string with a timestamp every 5 seconds to stdout and to a log file.
 

--- a/manifests/infra/agent-1/persistentvolume.yaml
+++ b/manifests/infra/agent-1/persistentvolume.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: agent-1-pv
+spec:
+  storageClassName: shared-agent-1-pv # this is the name you are using later to claim this volume
+  capacity:
+    storage: 1Gi # Could be e.q. 500Gi. Small amount is to preserve space when testing locally
+  volumeMode: Filesystem # This declares that it will be mounted into pods as a directory
+  accessModes:
+  - ReadWriteOnce
+  local:
+    path: /tmp/kube
+  nodeAffinity: ## This is only required for local, it defines which nodes can access it
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - k3d-k3s-default-agent-1

--- a/manifests/infra/agent-1/persistentvolumeclaim.yaml
+++ b/manifests/infra/agent-1/persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-volume-claim-1 # name of the volume claim, this will be used in the deployment
+spec:
+  storageClassName: shared-agent-1-pv # this is the name of the persistent volume we are claiming
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/todo-app/README.md
+++ b/todo-app/README.md
@@ -1,169 +1,135 @@
 # Chapter 3
 
-## Exercise: 2.2. The project, step 8
+## Exercise: 2.4. The project, step 9
 
-Moved from FLASK to FastAPI to get better performance and async support for image fetching.
+### Move todo-app and todo-backend to project namespace.
 
-### Clean up log_output
-
-Remove log_output since i have set todo app and log output app to use same port / path.
-I could have changed the ports to have the apps parallell, but this is simpler.
+Verify no deployments in default namespace:
 
 ```bash
-k delete -f log_output/manifests -f ping-pong_application/manifests
-deployment.apps "log-output-deployment" deleted
-ingress.networking.k8s.io "log-output-ingress" deleted
-service "log-output-svc" deleted
-deployment.apps "ping-pong-deployment" deleted
-ingress.networking.k8s.io "ping-pong-ingress" deleted
-service "ping-pong-svc" deleted
+➜ kubens default
+Context "k3d-k3s-default" modified.
+Active namespace is "default".
+➜ k get deployments.apps
+No resources found in default namespace.
 ```
 
-### Deploy todo-app
+create apps in project namespace:
 
 ```bash
-➜ k apply -f todo-app/manifests
+➜ k create namespace project
+namespace/project created
+➜ k apply -f todo-app/manifests -f todo-backend/manifests -n project
 deployment.apps/todo-app-deployment created
 ingress.networking.k8s.io/todo-app-ingress created
 service/todo-app-svc created
-```
-
-### Get todos
-
-Currently i return static todos if backend is not reachable.
-
-```bash
-➜ curl localhost:8081/
-
-    <h1>The project App</h1>
-    <img src="/image?ver=2025-09-03T09:07:10.997349+00:00" width="540" loading="lazy" alt="Random image" />
-    <form method="POST" action="/" style="margin-top:12px">
-      <input type="text" name="todo" required minlength="1" maxlength="140" size="40" />
-      <button type="submit">Create todo</button>
-    </form>
-    <ul>
-      <li>⬜️ Learn JavaScript</li><li>⬜️ Learn React</li><li>✅ Build a project</li>
-    </ul>
-    <strong>DevOps with Kubernetes 2025</strong>
-    %
-```
-
-### Deploy todo-backend
-
-```bash
-➜ k apply -f todo-backend/manifests
 deployment.apps/todo-backend-deployment created
 service/todo-backend-svc created
 ```
 
-### Verify todos from backend
+Verify app works.
 
 ```bash
 ➜ curl localhost:8081/
+404 page not found
+➜ k get deployments.apps
+No resources found in default namespace.
+➜ k get deployments.apps -n project
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+todo-app-deployment       0/1     1            0           22s
+todo-backend-deployment   1/1     1            1           22s
+```
+
+Check why deployment is not ready:
+
+```bash
+➜ kubens project
+Context "k3d-k3s-default" modified.
+Active namespace is "project".
+➜ k describe deployments.apps todo-app-deployment
+Name:                   todo-app-deployment
+Namespace:              project
+CreationTimestamp:      Wed, 03 Sep 2025 13:59:06 +0200
+Labels:                 <none>
+Annotations:            deployment.kubernetes.io/revision: 1
+Selector:               app=todo-app
+Replicas:               1 desired | 1 updated | 1 total | 0 available | 1 unavailable
+StrategyType:           RollingUpdate
+MinReadySeconds:        0
+RollingUpdateStrategy:  25% max unavailable, 25% max surge
+Pod Template:
+  Labels:  app=todo-app
+  Containers:
+   todo-app:
+    Image:      docker.io/pjmartin/todo-app:2.2@sha256:eb882290c4c6c85786854ec37b7c5f9501f217c423fae6753e5e68d557319139
+    Port:       <none>
+    Host Port:  <none>
+    Environment:
+      TODO_BACKEND_URL:  http://todo-backend-svc:2345
+      DATA_ROOT:         /app/data
+    Mounts:
+      /app/data from shared (rw)
+  Volumes:
+   shared:
+    Type:          PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+    ClaimName:     shared-volume-claim-0
+    ReadOnly:      false
+  Node-Selectors:  <none>
+  Tolerations:     <none>
+Conditions:
+  Type           Status  Reason
+  ----           ------  ------
+  Available      False   MinimumReplicasUnavailable
+  Progressing    True    ReplicaSetUpdated
+OldReplicaSets:  <none>
+NewReplicaSet:   todo-app-deployment-6bdd5c6df4 (1/1 replicas created)
+Events:
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  67s   deployment-controller  Scaled up replica set todo-app-deployment-6bdd5c6df4 to 1
+```
+
+Deployment is using persistent volume claim shared-volume-claim-0 which does not exist in the project namespace.
+
+Create a new persistent volume and claim in project namespace on agent-1 node:
+
+```bash
+
+➜ docker exec -ti k3d-k3s-default-agent-1 /bin/sh
+~ # mkdir /tmp/kube
+~ #
+➜ k apply -f manifests/infra/agent-1 -n project
+persistentvolume/agent-1-pv created
+persistentvolumeclaim/shared-volume-claim-1 created
+```
+
+update todo-app volume claim to use shared-volume-claim-1 in project namespace:
+
+```bash
+➜ k apply -f todo-app/manifests -n project
+deployment.apps/todo-app-deployment configured
+ingress.networking.k8s.io/todo-app-ingress unchanged
+service/todo-app-svc unchanged
+```
+
+check if deployment now works.
+
+```bash
+➜ k get deployments.apps -n project
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+todo-app-deployment       1/1     1            1           4m28s
+todo-backend-deployment   1/1     1            1           4m28s
+➜ curl localhost:8081/
 
     <h1>The project App</h1>
-    <img src="/image?ver=2025-09-03T09:07:10.997349+00:00" width="540" loading="lazy" alt="Random image" />
+    <img src="/image?ver=2025-09-03T12:03:46.771815+00:00" width="540" loading="lazy" alt="Random image" />
     <form method="POST" action="/" style="margin-top:12px">
       <input type="text" name="todo" required minlength="1" maxlength="140" size="40" />
       <button type="submit">Create todo</button>
     </form>
     <ul>
 
-    </ul>
-    <strong>DevOps with Kubernetes 2025</strong>
-```
-
-### Create todo
-
-```bash
-➜ curl -i -L \
-  -X POST 'http://localhost:8081/' \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  --data-urlencode 'todo=Buy milk'
-HTTP/1.1 303 See Other
-Content-Length: 0
-Date: Wed, 03 Sep 2025 09:26:04 GMT
-Location: /
-Server: uvicorn
-
-HTTP/1.1 422 Unprocessable Entity
-Content-Length: 89
-Content-Type: application/json
-Date: Wed, 03 Sep 2025 09:26:04 GMT
-Server: uvicorn
-
-{"detail":[{"type":"missing","loc":["body","todo"],"msg":"Field required","input":null}]}%
-```
-
-### Verify todo is created
-
-First task is now created.
-
-```bash
-curl localhost:8081/
-
-    <h1>The project App</h1>
-    <img src="/image?ver=2025-09-03T09:19:10.515162+00:00" width="540" loading="lazy" alt="Random image" />
-    <form method="POST" action="/" style="margin-top:12px">
-      <input type="text" name="todo" required minlength="1" maxlength="140" size="40" />
-      <button type="submit">Create todo</button>
-    </form>
-    <ul>
-      <li>⬜️ Buy milk</li>
     </ul>
     <strong>DevOps with Kubernetes 2025</strong>
     %
-```
-
-### Verify todo-app logs
-
-1. Todos backend is failing on request at 09:23:16,466
-2. Backend is started and reachable at 09:23:36,994
-
-```bash
-➜ k logs todo-app-deployment-6bdd5c6df4-7kg5h
-INFO:     Started server process [1]
-INFO:     Waiting for application startup.
-2025-09-03 09:23:05,820 INFO File logging -> /app/data/logs/todo-app.log
-2025-09-03 09:23:05,821 INFO todo-app started
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
-2025-09-03 09:23:16,466 WARNING Backend /todos failed: [Errno -2] Name or service not known
-INFO:     10.42.3.3:49308 - "GET / HTTP/1.1" 200 OK
-2025-09-03 09:23:36,994 INFO HTTP Request: GET http://todo-backend-svc:2345/todos "HTTP/1.1 200 OK"
-INFO:     10.42.3.3:37506 - "GET / HTTP/1.1" 200 OK
-2025-09-03 09:26:04,567 INFO HTTP Request: POST http://todo-backend-svc:2345/todos "HTTP/1.1 201 Created"
-INFO:     10.42.3.3:43556 - "POST / HTTP/1.1" 303 See Other
-INFO:     10.42.3.3:43556 - "POST / HTTP/1.1" 422 Unprocessable Entity
-2025-09-03 09:26:13,314 INFO HTTP Request: GET http://todo-backend-svc:2345/todos "HTTP/1.1 200 OK"
-INFO:     10.42.3.3:33052 - "GET / HTTP/1.1" 200 OK
-```
-
-3. Traffic is originating from IP 10.42.3.3 which is the Traefik proxy pod running on the same node as the todo-app.
-
-```bash
-➜ k get pods -A -o wide | grep '10.42.3.3'
-kube-system   traefik-5d45fc8cc9-dr5q4                   1/1     Running     0          6d      10.42.3.3    k3d-k3s-default-agent-0    <none>           <none>
-```
-
-### Verify todo-backend logs
-
-All requests are coming from 10.42.3.80 which is the todo-app pod.
-
-```bash
-➜ k logs todo-backend-deployment-7ddbc458dc-ptlf6
-INFO:     Started server process [1]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
-INFO:     10.42.3.80:34298 - "GET /todos HTTP/1.1" 200 OK
-INFO:     10.42.3.80:45886 - "POST /todos HTTP/1.1" 201 Created
-INFO:     10.42.3.80:39590 - "GET /todos HTTP/1.1" 200 OK
-```
-
-check IP of todo-app pod
-
-```bash
-➜ k get pods -A -o wide |grep '10.42.3.80'
-default       todo-app-deployment-6bdd5c6df4-7kg5h       1/1     Running     0          12m   10.42.3.80   k3d-k3s-default-agent-0    <none>           <none>
 ```

--- a/todo-app/manifests/deployment.yaml
+++ b/todo-app/manifests/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       volumes:
         - name: shared
           persistentVolumeClaim:
-            claimName: shared-volume-claim-0
+            claimName: shared-volume-claim-1
       containers:
         - name: todo-app
           image: docker.io/pjmartin/todo-app:2.2@sha256:eb882290c4c6c85786854ec37b7c5f9501f217c423fae6753e5e68d557319139


### PR DESCRIPTION
- Introduced exercise 2.4 in README.md for moving todo-app and todo-backend to project namespace.
- Changed endpoint in README.md from `/` to `/logs`.
- Updated deployment.yaml to use persistent volume claim `shared-volume-claim-1`.
- Added persistent volume and persistent volume claim YAML files for agent-1.